### PR TITLE
🐛 fix: support OTP paste on mobile browsers

### DIFF
--- a/src/lib/components/OtpItem.svelte
+++ b/src/lib/components/OtpItem.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { tick } from 'svelte';
+
 	interface Props {
 		input?: HTMLInputElement | null;
 		index: number;
@@ -49,53 +51,44 @@
 		}
 	}
 
+	async function distributeDigits(digits: string) {
+		const slice = digits.replace(/[^0-9]/g, '').slice(0, codes.length - index);
+		if (slice.length === 0) return;
+
+		const newCodes = [...codes];
+		for (let i = 0; i < slice.length; i++) {
+			newCodes[index + i] = slice[i];
+		}
+		codes = newCodes;
+		value = slice[0];
+
+		const focusAt = Math.min(index + slice.length, inputs.length - 1);
+		await tick();
+		inputs[focusAt]?.focus();
+	}
+
 	function handleInput(event: Event) {
+		// Mobile browsers fire `input` (not `paste`) when pasting, so this path must also
+		// distribute multi-char values across subsequent inputs.
 		const target = event.target as HTMLInputElement;
 		const inputValue = target.value.replace(/[^0-9]/g, '');
 
-		if (inputValue.length > 0) {
-			const newValue = inputValue[0];
-			value = newValue;
-			// Trigger reactivity by creating new array
-			const newCodes = [...codes];
-			newCodes[index] = newValue;
-			codes = newCodes;
-			// Clear extra characters and shift focus
-			target.value = newValue;
-			setTimeout(() => shiftFocus(), 0);
-		} else {
+		if (inputValue.length === 0) {
 			value = '';
 			const newCodes = [...codes];
 			newCodes[index] = '';
 			codes = newCodes;
+			return;
 		}
+
+		distributeDigits(inputValue);
 	}
 
 	function handlePaste(event: ClipboardEvent) {
 		event.preventDefault();
 		const paste = event.clipboardData?.getData('text');
 		if (!paste) return;
-
-		const numericPasteValue = paste.replace(/[^0-9]/g, '').slice(0, codes.length - index);
-		
-		// Update current input
-		if (numericPasteValue.length > 0) {
-			value = numericPasteValue[0];
-		}
-
-		// Update subsequent inputs
-		for (let i = 1; i < numericPasteValue.length; i++) {
-			if (index + i < codes.length) {
-				codes[index + i] = numericPasteValue[i];
-			}
-		}
-
-		const newFocusIndex = Math.min(index + numericPasteValue.length, inputs.length - 1);
-		setTimeout(() => {
-			if (newFocusIndex >= 0 && newFocusIndex < inputs.length && inputs[newFocusIndex]) {
-				(inputs[newFocusIndex] as HTMLInputElement).focus();
-			}
-		}, 0);
+		distributeDigits(paste);
 	}
 
 	function validateNumericInput(event: KeyboardEvent) {

--- a/src/lib/components/SvelteOtp.test.ts
+++ b/src/lib/components/SvelteOtp.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, fireEvent } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
 import SvelteOtp from './SvelteOtp.svelte';
@@ -54,6 +54,36 @@ describe('SvelteOtp', () => {
 		expect(inputs[2].value).toBe('3');
 		expect(inputs[3].value).toBe('4');
 		expect(inputs[4].value).toBe('5');
+		expect(inputs[5].value).toBe('6');
+	});
+
+	it('should distribute multi-char input when pasted on mobile (input event without paste event)', async () => {
+		render(SvelteOtp);
+		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+		inputs[0].focus();
+		await fireEvent.input(inputs[0], { target: { value: '123456' } });
+
+		expect(inputs[0].value).toBe('1');
+		expect(inputs[1].value).toBe('2');
+		expect(inputs[2].value).toBe('3');
+		expect(inputs[3].value).toBe('4');
+		expect(inputs[4].value).toBe('5');
+		expect(inputs[5].value).toBe('6');
+	});
+
+	it('should distribute multi-char input starting from a middle input', async () => {
+		render(SvelteOtp);
+		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+		inputs[2].focus();
+		await fireEvent.input(inputs[2], { target: { value: '9876' } });
+
+		expect(inputs[0].value).toBe('');
+		expect(inputs[1].value).toBe('');
+		expect(inputs[2].value).toBe('9');
+		expect(inputs[3].value).toBe('8');
+		expect(inputs[4].value).toBe('7');
 		expect(inputs[5].value).toBe('6');
 	});
 


### PR DESCRIPTION
## Why

Mobile browsers don't fire a `paste` event when users paste into an input — they only fire `input` with the pasted string already in `target.value`. The existing `handleInput` only kept the first character and discarded the rest, so mobile users ended up with only the first digit of their OTP in the first slot.

## What changed

`handleInput` and `handlePaste` now route through a single `distributeDigits` helper that fills subsequent inputs and advances focus. The prior near-duplication between the two handlers is gone.
