### PR TITLE
feat: autofill and label every otp input

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Here's an example component, styled using [tailwindcss](https://tailwindcss.com/
 | separator               | ''                | Separator between the individual inputs                     |
 | onlyShowMiddleSeparator | false             | Only show one separator in the middle (numOfInputs % 2 = 0) |
 | placeholder             | ''                | Placeholder value for the inputs                            |
+| autocomplete            | 'one-time-code'   | autocomplete attribute set on every input                   |
+| ariaLabel               | Digit {i} of {n}  | Builds each input's accessible name, for translation        |
 | disableDefaultStyle     | false             | Disable default styling of component                        |
 | wrapperClass            | ''                | Custom class to be added to the wrapper element             |
 | inputClass              | ''                | Custom class to be added to the individual inputs           |

--- a/src/lib/components/OtpItem.svelte
+++ b/src/lib/components/OtpItem.svelte
@@ -11,6 +11,8 @@
 		className: string;
 		style: string;
 		placeholder: string;
+		autocomplete: AutoFill;
+		ariaLabel: string;
 	}
 
 	let {
@@ -22,7 +24,9 @@
 		nostyle,
 		className,
 		style,
-		placeholder
+		placeholder,
+		autocomplete,
+		ariaLabel
 	}: Props = $props();
 
 	function shiftFocus(forward = true) {
@@ -119,6 +123,8 @@
 	onkeypress={validateNumericInput}
 	inputmode="numeric"
 	pattern="[0-9]*"
+	{autocomplete}
+	aria-label={ariaLabel}
 	{style}
 	{value}
 	{placeholder}

--- a/src/lib/components/SvelteOtp.svelte
+++ b/src/lib/components/SvelteOtp.svelte
@@ -14,6 +14,8 @@
 		separatorStyle?: string;
 		placeholder?: string;
 		onlyShowMiddleSeparator?: boolean;
+		autocomplete?: AutoFill;
+		ariaLabel?: (index: number, total: number) => string;
 	}
 
 	let {
@@ -28,7 +30,11 @@
 		wrapperStyle = '',
 		separatorStyle = '',
 		placeholder = '',
-		onlyShowMiddleSeparator = false
+		onlyShowMiddleSeparator = false,
+		// iOS and Android only offer a received code when every input asks for it.
+		// Marking just the first fills that one box and leaves the rest empty.
+		autocomplete = 'one-time-code',
+		ariaLabel = (index, total) => `Digit ${index} of ${total}`
 	}: Props = $props();
 
 	let codes = $state<string[]>([]);
@@ -82,6 +88,8 @@
 			className={inputClass}
 			style={inputStyle}
 			placeholder={placeholders[i]}
+			{autocomplete}
+			ariaLabel={ariaLabel(i + 1, numOfInputs)}
 		/>
 		{#if separator && i !== codes.length - 1 && (!onlyShowMiddleSeparator || (onlyShowMiddleSeparator && i === codes.length / 2 - 1 && numOfInputs % 2 === 0))}
 			<span class={separatorClass} style={separatorStyle}>{separator}</span>

--- a/src/lib/components/SvelteOtp.test.ts
+++ b/src/lib/components/SvelteOtp.test.ts
@@ -22,7 +22,7 @@ describe('SvelteOtp', () => {
 		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
 
 		await user.type(inputs[0], '1');
-		
+
 		// Check that focus moved to second input
 		expect(document.activeElement).toBe(inputs[1]);
 	});
@@ -98,5 +98,46 @@ describe('SvelteOtp', () => {
 		expect(inputs[0].value).toBe('1');
 		expect(inputs[1].value).toBe('2');
 		expect(inputs[2].value).toBe('3');
+	});
+
+	it('should ask every input for the one-time code', () => {
+		render(SvelteOtp);
+		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+		// Every one of them, not just the first: Safari fills a single box when
+		// the others opt out.
+		expect(inputs.map((input) => input.getAttribute('autocomplete'))).toEqual(
+			Array(6).fill('one-time-code')
+		);
+	});
+
+	it('should let the autocomplete be overridden', () => {
+		render(SvelteOtp, { autocomplete: 'off' });
+		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+		expect(inputs.map((input) => input.getAttribute('autocomplete'))).toEqual(Array(6).fill('off'));
+	});
+
+	it('should give each input a distinct accessible name', () => {
+		render(SvelteOtp, { numOfInputs: 4 });
+		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+		expect(inputs.map((input) => input.getAttribute('aria-label'))).toEqual([
+			'Digit 1 of 4',
+			'Digit 2 of 4',
+			'Digit 3 of 4',
+			'Digit 4 of 4'
+		]);
+	});
+
+	it('should let the accessible name be translated', () => {
+		render(SvelteOtp, {
+			numOfInputs: 3,
+			ariaLabel: (index: number, total: number) => `Chiffre ${index} sur ${total}`
+		});
+
+		expect(screen.getByLabelText('Chiffre 2 sur 3')).toBe(
+			(screen.getAllByRole('textbox') as HTMLInputElement[])[1]
+		);
 	});
 });


### PR DESCRIPTION
## Context

The inputs render with no `autocomplete` and no accessible name, so anyone wanting either has to reach into the rendered DOM and set the attributes by hand after mount.

That matters most for autofill: iOS distributes a received code across separate fields only when every one of them asks for it, so marking none (or only the first) fills a single box and leaves the rest empty. Screen readers also announced six unnamed text fields.

## Solution

Both are now props with defaults, `autocomplete` at `one-time-code` and `ariaLabel` building `Digit {i} of {n}`, so the common case needs no configuration while a consumer can still opt out of autofill or translate the label.