### PR TITLE
🐛 fix: replace a box's digit instead of pushing it into the next one

### DIFF
--- a/src/lib/components/OtpItem.svelte
+++ b/src/lib/components/OtpItem.svelte
@@ -73,13 +73,25 @@
 		inputs[focusAt]?.focus();
 	}
 
-	function handleInput(event: Event) {
-		// Mobile browsers fire `input` (not `paste`) when pasting, so this path must also
-		// distribute multi-char values across subsequent inputs.
-		const target = event.target as HTMLInputElement;
-		const inputValue = target.value.replace(/[^0-9]/g, '');
+	async function replaceDigit(target: HTMLInputElement, digit: string) {
+		const newCodes = [...codes];
+		newCodes[index] = digit;
+		codes = newCodes;
+		value = digit;
 
-		if (inputValue.length === 0) {
+		await tick();
+		// `value` is set as a one way attribute, so retyping the digit a box already holds
+		// changes no state and re-renders nothing, leaving the browser's two character
+		// string sitting in the box.
+		if (target.value !== digit) target.value = digit;
+		shiftFocus();
+	}
+
+	function handleInput(event: Event) {
+		const target = event.target as HTMLInputElement;
+		const digits = target.value.replace(/[^0-9]/g, '');
+
+		if (digits.length === 0) {
 			value = '';
 			const newCodes = [...codes];
 			newCodes[index] = '';
@@ -87,7 +99,28 @@
 			return;
 		}
 
-		distributeDigits(inputValue);
+		// A single typed character belongs to this box alone. When the box already holds a
+		// digit the browser reports both, and spreading that pair would push the old digit's
+		// neighbour out and corrupt the code.
+		const existing = codes[index] ?? '';
+		const typed = (event as InputEvent).data?.replace(/[^0-9]/g, '') ?? '';
+		const replacement =
+			typed.length === 1
+				? typed
+				: existing && digits.length === 2
+					? digits[0] === existing
+						? digits[1]
+						: digits[0]
+					: '';
+
+		if (replacement) {
+			replaceDigit(target, replacement);
+			return;
+		}
+
+		// Mobile browsers fire `input` (not `paste`) when pasting, so this path must also
+		// distribute multi-char values across subsequent inputs.
+		distributeDigits(digits);
 	}
 
 	function handlePaste(event: ClipboardEvent) {

--- a/src/lib/components/SvelteOtp.test.ts
+++ b/src/lib/components/SvelteOtp.test.ts
@@ -88,6 +88,39 @@ describe('SvelteOtp', () => {
 		expect(inputs[5].value).toBe('6');
 	});
 
+	it('should replace the digit in a box that already holds one', async () => {
+		const user = userEvent.setup();
+		render(SvelteOtp, { value: '123456', autofocus: false });
+		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+		// Caret sits after the existing digit, which is where a browser reports both the old
+		// and the new character together.
+		await user.type(inputs[0], '9', { initialSelectionStart: 1, initialSelectionEnd: 1 });
+
+		expect(inputs.map((input) => input.value)).toEqual(['9', '2', '3', '4', '5', '6']);
+	});
+
+	it('should leave one character behind when retyping the same digit', async () => {
+		const user = userEvent.setup();
+		render(SvelteOtp, { value: '123456', autofocus: false });
+		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+		await user.type(inputs[1], '2', { initialSelectionStart: 1, initialSelectionEnd: 1 });
+
+		expect(inputs[1].value).toBe('2');
+		expect(inputs[2].value).toBe('3');
+	});
+
+	it('should replace a middle digit without disturbing its neighbours', async () => {
+		const user = userEvent.setup();
+		render(SvelteOtp, { value: '123456', autofocus: false });
+		const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+		await user.type(inputs[3], '0', { initialSelectionStart: 1, initialSelectionEnd: 1 });
+
+		expect(inputs.map((input) => input.value)).toEqual(['1', '2', '3', '0', '5', '6']);
+	});
+
 	it('should only accept numeric values', async () => {
 		const user = userEvent.setup();
 		render(SvelteOtp, { autofocus: false });


### PR DESCRIPTION
## Problem

Correcting a digit you had already typed produced the wrong code. The input event carries the old character and the new one together, and both were spread across the following boxes, so `123456` with the caret after the `1` and a typed `9` became `193456` instead of `923456`. Retyping the same digit left a stale two character string in the box.

## Solution

A single typed character now replaces this box alone and moves focus on. Longer values still spread, which keeps the mobile paste path working, since those browsers deliver a pasted code as an `input` event rather than a `paste` event.

The three new tests fail on `main` with exactly the corruption above, and the behaviour is confirmed in a real browser as well as jsdom.

Closes #9